### PR TITLE
Add `st.cache` to load model

### DIFF
--- a/web_app/pizza_vision.py
+++ b/web_app/pizza_vision.py
@@ -76,7 +76,11 @@ topic_word = pickle.load(open('/app/pizza_vision/web_app/colab_topic_word.pickle
 tfidf = pickle.load(open('/app/pizza_vision/web_app/colab_tfidf.pickle', 'rb'))
 tfidf__mat = pickle.load(open('/app/pizza_vision/web_app/colab_tfidf_mat.pickle', 'rb'))
 
-resnet_model = ResNet50(weights='imagenet',include_top=False, input_shape=(224, 224, 3),pooling='max')
+@st.cache
+def load_resnet():
+    return ResNet50(weights='imagenet',include_top=False, input_shape=(224, 224, 3),pooling='max')
+    
+resnet_model = load_resnet()
 
 # Helper function to get the classname
 def classname(str):


### PR DESCRIPTION
Hi @ejfeldman7,

Johannes from the Streamlit team here :) I am currently investigating why apps run over the resource limits of Streamlit Sharing and saw that your app was affected in the past few days. 

Thought I'd send you a small PR that adds `st.cache` to your app, which should make it consume less memory (and not run into resource limits again!). More about this function [here](https://docs.streamlit.io/en/stable/caching.html). 

Hope this works for you and let me know if you have any other questions! 🎈

Cheers, Johannes